### PR TITLE
cleanup href="javascript:;" links

### DIFF
--- a/public/tpl/header.html
+++ b/public/tpl/header.html
@@ -9,7 +9,7 @@
     </div>
     <!-- END LOGO -->
             <!-- BEGIN RESPONSIVE MENU TOGGLER -->
-        <a href="javascript:;" class="menu-toggler btn btn-sm green-haze btn-outline">MENU</a>
+        <a href="#" class="menu-toggler btn btn-sm green-haze btn-outline">MENU</a>
         <!-- END RESPONSIVE MENU TOGGLER -->
         <!-- BEGIN TOP NAVIGATION MENU -->
         <div class="top-menu">
@@ -86,7 +86,7 @@
                     </ul>
                 </li>
                 <li class="menu-dropdown mega-menu-dropdown ">
-                    <a data-hover="megamenu-dropdown" data-close-others="true" data-toggle="dropdown" href="javascript:;" class="dropdown-toggle"> Stats
+                    <a data-hover="megamenu-dropdown" data-close-others="true" data-toggle="dropdown" href="#" class="dropdown-toggle"> Stats
                         <i class="fa fa-angle-down"></i>
                     </a>
                     <ul class="dropdown-menu">
@@ -123,7 +123,7 @@
                     </ul>
                 </li>
                 <li class="menu-dropdown classic-menu-dropdown ">
-                    <a data-hover="megamenu-dropdown" data-close-others="true" data-toggle="dropdown" href="javascript:;"> Misc
+                    <a data-hover="megamenu-dropdown" data-close-others="true" data-toggle="dropdown" href="#"> Misc
                         <i class="fa fa-angle-down"></i>
                     </a>
                     <ul class="dropdown-menu pull-left">
@@ -140,7 +140,7 @@
                     </ul>
                 </li>
                 <li class="menu-dropdown classic-menu-dropdown ">
-                    <a data-hover="megamenu-dropdown" data-close-others="true" data-toggle="dropdown" href="javascript:;"> Community
+                    <a data-hover="megamenu-dropdown" data-close-others="true" data-toggle="dropdown" href="#"> Community
                         <i class="fa fa-angle-down"></i>
                     </a>
                     <ul class="dropdown-menu pull-left">


### PR DESCRIPTION
iphone 사파리를 쓸 때 메뉴를 클릭하면 잘못된 팝업창이 뜹니다.
`href="javascript:;"`라고 되어있는 부분을 모두 `href="#"`로 고치면 이 문제는 사라집니다.